### PR TITLE
Allows openid logout using omniauth dynamic configuration

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -136,6 +136,8 @@ module OmniAuth
 
       def other_phase
         if logout_path_pattern.match?(current_path)
+          @env['omniauth.strategy'] = self
+          setup_phase
           options.issuer = issuer if options.issuer.to_s.empty?
           discover!
           return redirect(end_session_uri) if end_session_uri


### PR DESCRIPTION
The logout endpoint in OIDC needs to use oidc discovery to find the signoff endpoint. 

The gem requires the hash configuration in omniauth. We use dynamic providers, so the hash config doesn't work. 

This change calls the setup phase, which pulls in config from our config generator.